### PR TITLE
Release 2.1.0

### DIFF
--- a/GuardianConnect.xcodeproj/project.pbxproj
+++ b/GuardianConnect.xcodeproj/project.pbxproj
@@ -1202,7 +1202,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1217,7 +1217,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnect;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1237,7 +1237,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1252,7 +1252,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnect;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1380,7 +1380,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
@@ -1396,7 +1396,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnectMac;
 				PRODUCT_NAME = GuardianConnect;
 				SDKROOT = macosx;
@@ -1414,7 +1414,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 36;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
@@ -1430,7 +1430,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnectMac;
 				PRODUCT_NAME = GuardianConnect;
 				SDKROOT = macosx;

--- a/GuardianConnect.xcodeproj/project.pbxproj
+++ b/GuardianConnect.xcodeproj/project.pbxproj
@@ -1202,7 +1202,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1217,7 +1217,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnect;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1237,7 +1237,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1252,7 +1252,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnect;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1380,7 +1380,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
@@ -1396,7 +1396,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnectMac;
 				PRODUCT_NAME = GuardianConnect;
 				SDKROOT = macosx;
@@ -1414,7 +1414,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = FL2NUL637S;
@@ -1430,7 +1430,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sudosecuritygroup.GuardianConnectMac;
 				PRODUCT_NAME = GuardianConnect;
 				SDKROOT = macosx;

--- a/GuardianConnect/Classes/API/GRDGatewayAPI.h
+++ b/GuardianConnect/Classes/API/GRDGatewayAPI.h
@@ -71,10 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param completion completion block indicating a successful API request or an error message with detailed information
 - (void)setAlertsDownloadTimestampWithCompletion:(void(^)(BOOL success, NSString * _Nullable errorMessage))completion;
 
-/// endpoint: /api/v1.2/device/<eap-username>/alert-totals
-/// @param completion completion block indicating a successful API request, if successful a dictionary with the alert totals per alert category or an error message
-- (void)getAlertTotals:(void (^)(NSDictionary * _Nullable alertTotals, BOOL success, NSString * _Nullable errorMessage))completion;
-
 
 /// endpoint: /api/v1.1/<device_token>/set-push-token
 /// @param pushToken APNS push token sent to VPN server

--- a/GuardianConnect/Classes/API/GRDGatewayAPI.m
+++ b/GuardianConnect/Classes/API/GRDGatewayAPI.m
@@ -285,8 +285,8 @@
             if (completion) completion(nil, NO, @"An error occured!, Missing device id!");
             return;
         }
-        
-        NSString *apiEndpoint = [NSString stringWithFormat:@"/api/v1.1/device/%@/alerts", [self deviceIdentifier]];
+
+        NSString *apiEndpoint = [NSString stringWithFormat:@"/api/v1.2/device/%@/alerts", [self deviceIdentifier]];
         NSString *finalHost = [NSString stringWithFormat:@"https://%@%@", [self baseHostname], apiEndpoint];
         
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: [NSURL URLWithString:finalHost]];
@@ -451,63 +451,6 @@
         } else {
             GRDLog(@"Request failed with unknown status code: %ld", statusCode);
             if (completion) completion(NO, [NSString stringWithFormat:@"Request failed with unknown status code: %ld", statusCode]);
-        }
-    }];
-    [task resume];
-}
-
-- (void)getAlertTotals:(void (^)(NSDictionary * _Nullable, BOOL, NSString * _Nullable))completion {
-    if ([self _canMakeApiRequests] == NO) {
-        GRDLog(@"Cannot make API requests !!! won't continue");
-        if (completion) completion(nil, NO, @"cant make API requests");
-        return;
-    }
-    
-    if (![self deviceIdentifier]) {
-        if (completion) completion(nil, NO, @"An error occured!, Missing device id!");
-        return;
-    }
-    
-    NSString *apiEndpoint = [NSString stringWithFormat:@"/api/v1.1/device/%@/alert-totals", [self deviceIdentifier]];
-    NSString *finalHost = [NSString stringWithFormat:@"https://%@%@", [self baseHostname], apiEndpoint];
-    
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL: [NSURL URLWithString:finalHost]];
-    NSDictionary *jsonDict = @{kKeychainStr_APIAuthToken:[self apiAuthToken]};
-    [request setHTTPBody:[NSJSONSerialization dataWithJSONObject:jsonDict options:0 error:nil]];
-    [request setHTTPMethod:@"POST"];
-	[request setTimeoutInterval:30];
-	
-	NSURLSessionConfiguration *sessionConf = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-	[sessionConf setWaitsForConnectivity:YES];
-	[sessionConf setTimeoutIntervalForRequest:30];
-	[sessionConf setTimeoutIntervalForResource:30];
-	NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConf];
-    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
-            GRDLog(@"Failed to send request: %@", [error localizedDescription]);
-            if (completion) completion(nil, NO, [NSString stringWithFormat:@"Failed to send request: %@", [error localizedDescription]]);
-            return;
-        }
-        
-        NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-        if (statusCode == 500) {
-            GRDLog(@"Failed to get alert totals: Internal Server Error!");
-            if (completion) completion(nil, NO, @"Failed to get alert totals. Internal Server Error");
-            return;
-            
-        } else if (statusCode == 400) {
-            GRDLog(@"Failed to get alert totals: Bad request");
-            if (completion) completion(nil, NO, @"Failed to get alert totals: Malformed request!");
-            return;
-            
-        } else if (statusCode == 200) {
-            NSDictionary *alertTotals = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-            if (completion) completion(alertTotals, YES, nil);
-            return;
-            
-        } else {
-            GRDLog(@"Unknown server error. Status code: %ld", statusCode);
-            if (completion) completion(nil, NO, [NSString stringWithFormat:@"Unknown server error. Status code: %ld", statusCode]);
         }
     }];
     [task resume];

--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.h
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.h
@@ -80,11 +80,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param completion completion block returning an array of servers and indicating request success
 - (void)requestServersForRegion:(NSString * _Nonnull)region regionPrecision:(NSString * _Nonnull)precision paidServers:(BOOL)paidServers featureEnvironment:(GRDServerFeatureEnvironment)featureEnvironment betaCapableServers:(BOOL)betaCapable completion:(void (^)(NSArray * _Nullable, NSError * _Nullable))completion;
 
-/// endpoint: /api/v1/servers/all-server-regions
-/// Used to retrieve all available Server Regions from housekeeping to allow users to override the selected Server Region
-/// @param completion completion block returning an array contain a dictionary for each server region and a BOOL indicating a successful API call
-- (void)requestAllServerRegions:(void (^)(NSArray <NSDictionary *> * _Nullable items, BOOL success, NSError * _Nullable errorMessage))completion DEPRECATED_MSG_ATTRIBUTE("Use -requestAllServerRegionsWithPrecision: instead");
-
 /// endpoint: /api/v1.3/servers/all-server-regions/:precision
 /// @param precision one of the region precision constants
 /// @param completion completion block containing an error or the array of all regions for the requested region-precision

--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
@@ -438,35 +438,6 @@
 	[task resume];
 }
 
-- (void)requestAllServerRegions:(void (^)(NSArray <NSDictionary *> * _Nullable items, BOOL success, NSError * _Nullable errorMessage))completion {
-    NSMutableURLRequest *request = [self housekeepingAPIRequestFor:@"/api/v1/servers/all-server-regions"];
-	
-	NSURLSessionConfiguration *sessionConf = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-	[sessionConf setWaitsForConnectivity:YES];
-	[sessionConf setTimeoutIntervalForRequest:15];
-	[sessionConf setTimeoutIntervalForResource:15];
-	NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConf];
-    NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-        if (error != nil) {
-            if (completion) completion(nil, NO, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:[NSString stringWithFormat:@"Failed to get retrieve all regions: %@", [error localizedDescription]]]);
-			return;
-        }
-        
-		NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-		if (statusCode != 200) {
-			GRDAPIError *apiErr = [[GRDAPIError alloc] initWithData:data andStatusCode:statusCode];
-			GRDErrorLogg(@"Failed to retrieve regions. Error title: %@ message: %@ status code: %ld", apiErr.title, apiErr.message, statusCode);
-			if (completion) completion(nil, NO, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:[NSString stringWithFormat:@"Unknown error: %@ - Status code: %ld", apiErr.message, statusCode]]);
-			return;
-		}
-		
-		NSArray *returnItems = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-		if (completion) completion(returnItems, YES, nil);
-		return;
-    }];
-    [task resume];
-}
-
 - (void)requestAllServerRegionsWithPrecision:(NSString * _Nonnull)precision completion:(void (^)(NSArray <NSDictionary *> * _Nullable items, NSError * _Nullable error))completion {
 	NSMutableURLRequest *request = [self housekeepingAPIRequestFor:[NSString stringWithFormat:@"/api/v1.3/servers/all-server-regions/%@", precision]];
 	

--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
@@ -376,6 +376,24 @@
 }
 
 - (void)requestServersForRegion:(NSString *)region regionPrecision:(NSString *)precision paidServers:(BOOL)paidServers featureEnvironment:(GRDServerFeatureEnvironment)featureEnvironment betaCapableServers:(BOOL)betaCapable completion:(void (^)(NSArray *, NSError *))completion {
+	GRDWarningLogg(@"Received values:");
+	GRDWarningLogg(@"Region: %@", region);
+	GRDWarningLogg(@"Precision: %@", precision);
+	GRDWarningLogg(@"Paid servers: %@", paidServers ? @"YES" : @"NO");
+	GRDWarningLogg(@"Server envrionment: %@", featureEnvironment);
+	GRDWarningLogg(@"Beta capable: %@", betaCapable ? @"YES" : @"NO");
+	
+	if (region == nil) {
+		if (completion) completion(nil, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:@"Unable to proceed, null region provided!"]);
+		return;
+	}
+	
+	if (precision == nil) {
+		if (completion) completion(nil, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:@"Unable to proceed, null precision provided!"]);
+		return;
+	}
+	
+	
 	NSNumber *payingUserAsNumber = [NSNumber numberWithBool:paidServers];
 	NSNumber *featureEnvAsInt = [NSNumber numberWithInt:(int)featureEnvironment];
 	NSError *jsonErr;

--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
@@ -380,7 +380,7 @@
 	GRDWarningLogg(@"Region: %@", region);
 	GRDWarningLogg(@"Precision: %@", precision);
 	GRDWarningLogg(@"Paid servers: %@", paidServers ? @"YES" : @"NO");
-	GRDWarningLogg(@"Server envrionment: %@", featureEnvironment);
+	GRDWarningLogg(@"Server envrionment: %d", (int)featureEnvironment);
 	GRDWarningLogg(@"Beta capable: %@", betaCapable ? @"YES" : @"NO");
 	
 	if (region == nil) {

--- a/GuardianConnect/Classes/API/GRDRegion.h
+++ b/GuardianConnect/Classes/API/GRDRegion.h
@@ -51,6 +51,22 @@ NS_ASSUME_NONNULL_BEGIN
 /// user in any given region
 @property NSNumber *serverCount;
 
+/// The amount of secure gateway servers tied to the region
+/// which support the smart routing proxy capability
+@property NSNumber *smartRoutingProxyServers;
+
+/// A constant indicator representing the state of the smart
+/// routing proxy capability support for the region
+/// 
+/// Eg. if GRDRegion.serverCount == GRDRegion.smartRoutingProxyServers
+/// this string will be set to kGRDRegionSmartRoutingProxyAll
+///
+/// Will be one of
+/// - kGRDRegionSmartRoutingProxyNone
+/// - kGRDRegionSmartRoutingProxySome
+/// - kGRDRegionSmartRoutingProxyAll
+@property NSString *smartRoutingProxyState;
+
 /// If the region precision kGRDRegionPrecisionCityByCountry is
 /// selected this property will contain an array of regions pointing
 /// to cities that are mapped to the country

--- a/GuardianConnect/Classes/API/GRDRegion.m
+++ b/GuardianConnect/Classes/API/GRDRegion.m
@@ -14,16 +14,18 @@
 - (instancetype)initWithDictionary:(NSDictionary *)regionDict {
     self = [super init];
     if (self) {
-        self.continent 			= regionDict[@"continent"];
-		self.country 			= regionDict[@"country"];
-		self.countryISOCode 	= regionDict[@"country-iso-code"];
-        self.regionName 		= regionDict[@"name"];
-        self.displayName 		= regionDict[@"name-pretty"];
-        self.isAutomatic 		= false;
-		self.regionPrecision 	= regionDict[@"region-precision"];
-		self.latitude			= regionDict[@"latitude"];
-		self.longitude			= regionDict[@"longitude"];
-		self.serverCount		= regionDict[@"server-count"];
+        self.continent 					= regionDict[@"continent"];
+		self.country 					= regionDict[@"country"];
+		self.countryISOCode 			= regionDict[@"country-iso-code"];
+        self.regionName 				= regionDict[@"name"];
+        self.displayName 				= regionDict[@"name-pretty"];
+        self.isAutomatic 				= false;
+		self.regionPrecision 			= regionDict[@"region-precision"];
+		self.latitude					= regionDict[@"latitude"];
+		self.longitude					= regionDict[@"longitude"];
+		self.serverCount				= regionDict[@"server-count"];
+		self.smartRoutingProxyServers 	= regionDict[@"smart-routing-proxy-servers"];
+		self.smartRoutingProxyState 	= regionDict[@"smart-routing-proxy-state"];
 		
 		NSArray *rawCities = regionDict[@"cities"];
 		NSMutableArray *cities = [NSMutableArray new];
@@ -53,18 +55,20 @@
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
 	self = [super init];
 	if (self) {
-		self.continent 			= [coder decodeObjectForKey:@"continent"];
-		self.country 			= [coder decodeObjectForKey:@"country"];
-		self.countryISOCode 	= [coder decodeObjectForKey:@"country-iso-code"];
-		self.regionName 		= [coder decodeObjectForKey:@"name"];
-		self.displayName 		= [coder decodeObjectForKey:@"name-pretty"];
-		self.isAutomatic 		= [[coder decodeObjectForKey:@"is-automatic"] boolValue];
-		self.regionPrecision 	= [coder decodeObjectForKey:@"region-precision"];
-		self.latitude 			= [coder decodeObjectForKey:@"latitude"];
-		self.longitude			= [coder decodeObjectForKey:@"longitude"];
-		self.serverCount		= [coder decodeObjectForKey:@"server-count"];
-		self.cities				= [coder decodeObjectForKey:@"cities"];
-		self.timeZoneName		= [coder decodeObjectForKey:@"time-zone-name"];
+		self.continent 					= [coder decodeObjectForKey:@"continent"];
+		self.country 					= [coder decodeObjectForKey:@"country"];
+		self.countryISOCode 			= [coder decodeObjectForKey:@"country-iso-code"];
+		self.regionName 				= [coder decodeObjectForKey:@"name"];
+		self.displayName 				= [coder decodeObjectForKey:@"name-pretty"];
+		self.isAutomatic 				= [[coder decodeObjectForKey:@"is-automatic"] boolValue];
+		self.regionPrecision 			= [coder decodeObjectForKey:@"region-precision"];
+		self.latitude 					= [coder decodeObjectForKey:@"latitude"];
+		self.longitude					= [coder decodeObjectForKey:@"longitude"];
+		self.serverCount				= [coder decodeObjectForKey:@"server-count"];
+		self.cities						= [coder decodeObjectForKey:@"cities"];
+		self.timeZoneName				= [coder decodeObjectForKey:@"time-zone-name"];
+		self.smartRoutingProxyServers 	= [coder decodeObjectForKey:@"smart-routing-proxy-servers"];
+		self.smartRoutingProxyState 	= [coder decodeObjectForKey:@"smart-routing-proxy-state"];
 	}
 	
 	return self;
@@ -83,13 +87,16 @@
 	[coder encodeObject:self.serverCount forKey:@"server-count"];
 	[coder encodeObject:self.cities forKey:@"cities"];
 	[coder encodeObject:self.timeZoneName forKey:@"time-zone-name"];
+	[coder encodeObject:self.smartRoutingProxyServers forKey:@"smart-routing-proxy-servers"];
+	[coder encodeObject:self.smartRoutingProxyState forKey:@"smart-routing-proxy-state"];
 }
 
 + (BOOL)supportsSecureCoding {
 	return YES;
 }
 
-//overriding equality check because we MIGHT be missint contitent if we are recreated by GRDVPNHelper during credential loading.
+// Overriding equality check because we might be missint contitent
+// if we are recreated by GRDVPNHelper during credential loading.
 - (BOOL)isEqual:(id)object {
     if (![object isKindOfClass:self.class]) {
         return false;
@@ -153,6 +160,7 @@
             [newRegions addObject:region];
         }
     }];
+	
     return [newRegions sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"displayName" ascending:true]]];
 }
 

--- a/GuardianConnect/Classes/API/GRDServerManager.m
+++ b/GuardianConnect/Classes/API/GRDServerManager.m
@@ -232,9 +232,9 @@
 }
 
 - (void)getRegionsWithCompletion:(void (^)(NSArray<GRDRegion *> * _Nullable regions))completion {
-	[[GRDHousekeepingAPI new] requestAllServerRegions:^(NSArray<NSDictionary *> * _Nullable items, BOOL success, NSError * _Nullable errorMessage) {
-		if (!success) {
-			GRDErrorLogg(@"Failed to fetch server regions from API. Error: %@", [errorMessage localizedDescription]);
+	[[GRDHousekeepingAPI new] requestAllServerRegionsWithPrecision:kGRDRegionPrecisionDefault completion:^(NSArray<NSDictionary *> * _Nullable items, NSError * _Nullable error) {
+		if (error != nil) {
+			GRDErrorLogg(@"Failed to fetch server regions from API. Error: %@", [error localizedDescription]);
 			if (completion) completion(nil);
 			return;
 		}

--- a/GuardianConnect/Classes/GRDVPNHelper.h
+++ b/GuardianConnect/Classes/GRDVPNHelper.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GRDVPNHelper : NSObject
 
+@property NEVPNManager *currentTunnelManager;
+
 /// The GuardianConnect API hostname to use for the majority of API calls
 /// WARNING: Some API endpoints are always going to use the public Connect
 /// API hostname https://connect-api.guardianapp.com

--- a/GuardianConnect/Classes/GRDVPNHelper.m
+++ b/GuardianConnect/Classes/GRDVPNHelper.m
@@ -964,7 +964,7 @@
 }
 
 - (NSError * _Nullable)selectRegion:(GRDRegion * _Nullable)selectedRegion {
-	_selectedRegion = selectedRegion;
+	self.selectedRegion = selectedRegion;
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	if (selectedRegion != nil && selectedRegion.isAutomatic == NO) {
 		NSError *archiveErr;

--- a/GuardianConnect/Classes/GRDVPNHelper.m
+++ b/GuardianConnect/Classes/GRDVPNHelper.m
@@ -420,6 +420,7 @@
 						dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 							[vpnManager loadFromPreferencesWithCompletionHandler:^(NSError * _Nullable error) {
 								NSError *vpnErr;
+								self.currentTunnelManager = vpnManager;
 								[[vpnManager connection] startVPNTunnelAndReturnError:&vpnErr];
 								if (vpnErr != nil) {
 									GRDErrorLogg(@"[IKEv2] Failed to start VPN: %@", vpnErr);
@@ -513,7 +514,7 @@
 		protocol.providerBundleIdentifier 	= self.tunnelProviderBundleIdentifier;
 		protocol.passwordReference 			= [GRDKeychain getPasswordRefForAccount:kKeychainStr_WireGuardConfig];
 		protocol.username 					= [self.mainCredential clientId];
-		protocol.proxySettings = [GRDVPNHelper proxySettingsForSGWServer:self.mainCredential.server];
+		protocol.proxySettings 				= [GRDVPNHelper proxySettingsForSGWServer:self.mainCredential.server];
 		
 		if (@available(iOS 14.2, *)) {
 			protocol.includeAllNetworks = self.vpnKillSwitchEnabled;
@@ -546,6 +547,7 @@
 				}
 				
 				NETunnelProviderSession *session = (NETunnelProviderSession*)tunnelManager.connection;
+				self.currentTunnelManager = tunnelManager;
 				
 #if TARGET_OS_MAC && !TARGET_OS_IPHONE
 				if ([session respondsToSelector:@selector(sendProviderMessage:returnError:responseHandler:)]) {

--- a/GuardianConnect/Classes/GRDVPNHelper.m
+++ b/GuardianConnect/Classes/GRDVPNHelper.m
@@ -880,7 +880,11 @@
 	//
 	// Note from CJ 2024-09-27
 	// Yup, still going strong
-	if ([subCred.subscriptionType isEqualToString:kGuardianFreeTrial3Days]) {
+	//
+	// Note from CJ 2025-03-13
+	// Tiny edit to remove things that
+	// do not need to be part of the SDK
+	if ([subCred.subscriptionType isEqualToString:@"grd_trial_3_days"]) {
 		eapCredentialsValidFor = 3;
 	}
 	return eapCredentialsValidFor;

--- a/GuardianConnect/Shared.h
+++ b/GuardianConnect/Shared.h
@@ -112,6 +112,12 @@ static NSString * const kGRDRegionPrecisionCityByCountry	= @"city-by-country";
 static NSString * const kGRDPreferredRegionPrecisionCustom	= @"kGRDPreferredRegionPrecisionCustom";
 
 
+#pragma mark - Smart Proxy Routing region states
+static NSString * const kGRDRegionSmartRoutingProxyNone = @"none";
+static NSString * const kGRDRegionSmartRoutingProxySome = @"some";
+static NSString * const kGRDRegionSmartRoutingProxyAll 	= @"all";
+
+
 # pragma mark - Trusted Network constants
 static NSString * const kGRDDisconnectOnTrustedNetworks	= @"kGRDDisconnectOnTrustedNetworks";
 static NSString * const kGRDTrustedNetworksArray		= @"kGRDTrustedNetworksArray";

--- a/GuardianConnect/Shared.h
+++ b/GuardianConnect/Shared.h
@@ -85,35 +85,8 @@ static NSString * const kGRDLastKnownAutomaticRegion	 				= @"kGRDLastKnownAutom
 
 
 #pragma mark - Subscription types + related
-static NSString * const kGuardianSubscriptionTypeEssentials             = @"grd_type_essentials";
-static NSString * const kGuardianSubscriptionDayPass                    = @"grd_day_pass";
-static NSString * const kGuardianSubscriptionDayPassAlt                 = @"grd_day_pass_alt";
-static NSString * const kGuardianSubscriptionGiftedDayPass              = @"grd_gifted_day_pass";
-static NSString * const kGuardianSubscriptionCustomDayPass              = @"custom_day_pass";
-static NSString * const kGuardianSubscriptionMonthly                    = @"grd_monthly";
-static NSString * const kGuardianSubscriptionThreeMonths                = @"grd_three_months";
-static NSString * const kGuardianSubscriptionAnnual                     = @"grd_annual";
-static NSString * const kGuardianSubscriptionTypeProfessionalIAP        = @"grd_pro";
-static NSString * const kGuardianSubscriptionTypeCustomDayPass          = @"grd_custom_day_pass";
-static NSString * const kGuardianSubscriptionTypeIntroductory           = @"grd_day_pass_introductory";
-// "grd_teams" is an umbrealla description. Should never be used in production since it does not accurately describe the subscription length etc.
-static NSString * const kGuardianSubscriptionTypeTeams 					= @"grd_teams";
-static NSString * const kGuardianSubscriptionTypeTeamsAnnual			= @"grd_teams_annual";
 
-static NSString * const kGuardianFreeTrial3Days                         = @"grd_trial_3_days";
-static NSString * const kGuardianExtendedTrial30Days                    = @"grd_extended_trial_30_days";
-static NSString * const kGuardianTrialBalanceDayPasses                  = @"grd_trial_balance_day_passes";
-static NSString * const kGuardianSubscriptionFreeTrial                  = @"free_trial";
 
-static NSString * const kGuardianSubscriptionTypeVisionary              = @"grd_visionary";
-static NSString * const kGuardianSubscriptionTypeProfessionalMonthly    = @"grd_pro_monthly";
-static NSString * const kGuardianSubscriptionTypeProfessionalYearly     = @"grd_pro_yearly";
-static NSString * const kGuardianSubscriptionTypeProfessionalBrave      = @"bravevpn.yearly-pro";
-
-static NSString * const kGuardianFreeTrialPeTokenSet                    = @"kGRDFreeTrialPETokenSet";
-static NSString * const kGuardianDayPassExpirationDate                  = @"GuardianDayPassExpirationDate";
-
-static NSString * const kGuardianSubscriptionProductIds                 = @"kGuardianSubscriptionProductIds";
 
 // Used to hard to code IAP receipts and create Subscriber Credentials
 static NSString * const kGuardianEncodedAppStoreReceipt 						= @"kGuardianEncodedAppStoreReceipt";
@@ -121,20 +94,16 @@ static NSString * const kGuardianPreferredSubscriberCredentialValidationMethod 	
 
 //moved to make framework friendly
 static NSString * const kIsPremiumUser                                  = @"userHasPaidSubscription";
-static NSString * const kSubscriptionPlanTypeStr                        = @"subscriptionPlanType";
 
-typedef NS_ENUM(NSInteger, GRDPlanDetailType) {
-    GRDPlanDetailTypeFree = 0,
-    GRDPlanDetailTypeEssentials,
-    GRDPlanDetailTypeProfessional
-};
 
-#define kGRDServerUpdatedNotification @"GRDServerUpdatedNotification"
-#define kGRDLocationUpdatedNotification @"GRDLocationUpdatedNotification"
+
+
+#define kGRDServerUpdatedNotification 		@"GRDServerUpdatedNotification"
+#define kGRDLocationUpdatedNotification 	@"GRDLocationUpdatedNotification"
 #define kGRDSubscriptionUpdatedNotification @"GRDSubscriptionUpdatedNotification"
 
 
-#pragma mark - Region precision constant
+#pragma mark - Region precision constants
 static NSString * const kGRDPreferredRegionPrecision 		= @"kGRDPreferredRegionPrecision";
 static NSString * const kGRDRegionPrecisionDefault 			= @"default";
 static NSString * const kGRDRegionPrecisionCity 			= @"city";
@@ -148,11 +117,6 @@ static NSString * const kGRDDisconnectOnTrustedNetworks	= @"kGRDDisconnectOnTrus
 static NSString * const kGRDTrustedNetworksArray		= @"kGRDTrustedNetworksArray";
 
 static NSString * const kGRDKillSwitchEnabled       	= @"kGRDKillSwitchEnabled";
-
-static NSString * const kGRDTrialExpirationInterval =          @"kGRDTrialExpirationInterval";
-static NSString * const kGRDFreeTrialExpired =                 @"kGRDFreeTrialExpired";
-
-
 
 static NSString * const kGRDDeviceFilterConfigBlocklist = @"kGRDDeviceFilterConfigBlocklist";
 

--- a/iOSSampleApp/ViewController.swift
+++ b/iOSSampleApp/ViewController.swift
@@ -78,24 +78,23 @@ class ViewController: UIViewController {
     func startRefreshTimer() {
         self.stopRefreshTimer() //this only stops the timer if applicable
         timer = Timer.scheduledTimer(withTimeInterval: 20, repeats: true, block: { (timer) in
-            GRDGatewayAPI().getAlertTotals { (results, success, errorMessage) in
-                if (success) {
-                    let resp: Dictionary = results! as! Dictionary<String, AnyObject>
-                    //print(resp)
-                    //["page-hijacker-total": 0, "data-tracker-total": 0, "location-tracker-total": 0, "mail-tracker-total": 0]
-                    let pht = "Page Hijackers: \(resp["page-hijacker-total"] ?? "0" as AnyObject)"
-                    let dtt = "Data Trackers: \(resp["data-tracker-total"] ?? "0" as AnyObject)"
-                    let ltt = "Location Trackers: \(resp["location-tracker-total"] ?? "0" as AnyObject)"
-                    let mtt = "Mail Trackers: \(resp["mail-tracker-total"] ?? "0" as AnyObject)"
-                    DispatchQueue.main.async {
-                        self.dataTrackerLabel.text = dtt
-                        self.pageHijackerLabel.text = pht
-                        self.locationTrackerLabel.text = ltt
-                        self.mailTrackerLabel.text = mtt
-                    }
-                }
-                
-            }
+//            GRDGatewayAPI().getAlertTotals { (results, success, errorMessage) in
+//                if (success) {
+//                    let resp: Dictionary = results! as! Dictionary<String, AnyObject>
+//                    //print(resp)
+//                    //["page-hijacker-total": 0, "data-tracker-total": 0, "location-tracker-total": 0, "mail-tracker-total": 0]
+//                    let pht = "Page Hijackers: \(resp["page-hijacker-total"] ?? "0" as AnyObject)"
+//                    let dtt = "Data Trackers: \(resp["data-tracker-total"] ?? "0" as AnyObject)"
+//                    let ltt = "Location Trackers: \(resp["location-tracker-total"] ?? "0" as AnyObject)"
+//                    let mtt = "Mail Trackers: \(resp["mail-tracker-total"] ?? "0" as AnyObject)"
+//                    DispatchQueue.main.async {
+//                        self.dataTrackerLabel.text = dtt
+//                        self.pageHijackerLabel.text = pht
+//                        self.locationTrackerLabel.text = ltt
+//                        self.mailTrackerLabel.text = mtt
+//                    }
+//                }
+//            }
         })
     }
     


### PR DESCRIPTION
- Minor cleanup of various deprecated functions + bumping API versions to supported versions
- Parse & expose smart routing proxy state as well as server count supporting the capability in a given `GRDRegion` returned by the API