### PR TITLE
GRD-1391: add Stealth Mode (direct-IP VPN dialing)

### DIFF
--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.h
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.h
@@ -90,6 +90,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param completion completion block containing an error or the array of smart routing proxy hosts
 - (void)requestSmartProxyRoutingHostsWithCompletion:(void (^)(NSArray * _Nullable smartProxyHosts, NSError * _Nullable error))completion;
 
+/// endpoint: /api/v1.3/infrastructure/sgw-ips/all
+/// Stealth Mode (GRD-1391): fetches the full secure-gateway hostname -> IPv4 map so the
+/// client can dial servers by IP on hostile networks where DNS is poisoned. The map is
+/// cached by GRDVPNHelper; this method only performs the network fetch and transforms the
+/// backend's array response into a dictionary keyed by hostname.
+/// @param completion completion block returning a dictionary of hostname -> IPv4 string, or an error
+- (void)requestAllServerIPsWithCompletion:(void (^)(NSDictionary<NSString *, NSString *> * _Nullable ipMap, NSError * _Nullable error))completion;
+
 
 # pragma mark - Connect Subscriber
 

--- a/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
+++ b/GuardianConnect/Classes/API/GRDHousekeepingAPI.m
@@ -467,6 +467,59 @@
 	[task resume];
 }
 
+- (void)requestAllServerIPsWithCompletion:(void (^)(NSDictionary<NSString *, NSString *> * _Nullable, NSError * _Nullable))completion {
+	// Stealth Mode (GRD-1391): reuse the existing public infrastructure endpoint that already
+	// exposes servers.ipv4. Routed via housekeepingAPIRequestFor: so it targets the same host
+	// (connect-api.guardianapp.com by default) and honours any env override, exactly like the
+	// other /servers endpoints.
+	NSMutableURLRequest *request = [self housekeepingAPIRequestFor:@"/api/v1.3/infrastructure/sgw-ips/all"];
+
+	NSURLSessionConfiguration *sessionConf = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+	[sessionConf setWaitsForConnectivity:YES];
+	[sessionConf setTimeoutIntervalForRequest:15];
+	[sessionConf setTimeoutIntervalForResource:15];
+	NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConf];
+	NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+		if (error != nil) {
+			if (completion) completion(nil, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:[NSString stringWithFormat:@"Failed to retrieve secure gateway IPs: %@", [error localizedDescription]]]);
+			return;
+		}
+
+		NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+		if (statusCode != 200) {
+			GRDAPIError *apiErr = [[GRDAPIError alloc] initWithData:data andStatusCode:statusCode];
+			GRDErrorLogg(@"Failed to retrieve secure gateway IPs. Error title: %@ message: %@ status code: %ld", apiErr.title, apiErr.message, statusCode);
+			if (completion) completion(nil, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:[NSString stringWithFormat:@"Unknown error: %@ - Status code: %ld", apiErr.message, statusCode]]);
+			return;
+		}
+
+		NSArray *serverItems = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+		if ([serverItems isKindOfClass:[NSArray class]] == NO) {
+			if (completion) completion(nil, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:@"Malformed secure gateway IP response"]);
+			return;
+		}
+
+		// Fold [{hostname, ipv4, ...}] into a hostname -> ipv4 map. IPv4-only by design
+		// (GRD-1391 future work: IPv6). Skip entries missing a usable v4 address so the
+		// lookup simply misses and the caller falls back to the FQDN.
+		NSMutableDictionary<NSString *, NSString *> *ipMap = [NSMutableDictionary new];
+		for (NSDictionary *item in serverItems) {
+			if ([item isKindOfClass:[NSDictionary class]] == NO) continue;
+			NSString *hostname = item[@"hostname"];
+			NSString *ipv4 = item[@"ipv4"];
+			if ([hostname isKindOfClass:[NSString class]] == NO || hostname.length == 0) continue;
+			if ([ipv4 isKindOfClass:[NSString class]] == NO || ipv4.length == 0) continue;
+			if ([ipv4 isEqualToString:@"0.0.0.0"]) continue;
+			if ([[ipv4 componentsSeparatedByString:@"."] count] != 4) continue; // crude IPv4 sanity check
+			ipMap[hostname] = ipv4;
+		}
+
+		if (completion) completion(ipMap, nil);
+		return;
+	}];
+	[task resume];
+}
+
 - (void)requestSmartProxyRoutingHostsWithCompletion:(void (^)(NSArray * _Nullable, NSError * _Nullable))completion {
 	NSMutableURLRequest *request = [self housekeepingAPIRequestFor:@"/api/v1/smart-proxy-routing/hosts"];
 	[request setHTTPMethod:@"GET"];

--- a/GuardianConnect/Classes/API/GRDSGWServer.h
+++ b/GuardianConnect/Classes/API/GRDSGWServer.h
@@ -14,6 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GRDSGWServer : NSObject <NSSecureCoding>
 
 @property NSString 		*hostname;
+/// Direct IPv4 address of the secure gateway, used by Stealth Mode (GRD-1391) to dial
+/// the server without a DNS lookup of `hostname`. May be nil if the backend did not
+/// supply one; callers must fall back to `hostname` in that case.
+/// IPv6 is intentionally not modelled yet — see GRD-1391 future work.
+@property NSString 		* _Nullable serverIPv4;
 @property NSString 		*displayName;
 @property BOOL 			offline;
 @property NSUInteger	capacityScore;

--- a/GuardianConnect/Classes/API/GRDSGWServer.m
+++ b/GuardianConnect/Classes/API/GRDSGWServer.m
@@ -14,6 +14,11 @@
 	self = [super init];
 	if (self) {
 		self.hostname = dict[@"hostname"];
+		// Stealth Mode (GRD-1391): forward-compatible parse of a direct server IP if the
+		// backend ever includes it inline in the server list. In v1 this is normally nil
+		// because IPs are sourced from the separately-cached sgw-ips map; nil is fine and
+		// callers fall back to `hostname`.
+		self.serverIPv4 = dict[@"ipv4"];
 		self.displayName = dict[@"display-name"];
 		NSNumber *offlineNum = dict[@"offline"];
 		self.offline = [offlineNum boolValue];
@@ -47,6 +52,7 @@
 	self = [super init];
 	if (self) {
 		self.hostname 					= [coder decodeObjectForKey:@"hostname"];
+		self.serverIPv4 				= [coder decodeObjectForKey:@"serverIPv4"]; // GRD-1391
 		self.displayName 				= [coder decodeObjectForKey:@"displayName"];
 		self.offline 					= [coder decodeBoolForKey:@"offline"];
 		self.capacityScore 				= [coder decodeIntegerForKey:@"capacityScore"];
@@ -61,6 +67,7 @@
 
 - (void)encodeWithCoder:(NSCoder *)coder {
 	[coder encodeObject:self.hostname forKey:@"hostname"];
+	[coder encodeObject:self.serverIPv4 forKey:@"serverIPv4"]; // GRD-1391
 	[coder encodeObject:self.displayName forKey:@"displayName"];
 	[coder encodeBool:self.offline forKey:@"offline"];
 	[coder encodeInteger:self.capacityScore forKey:@"capacityScore"];

--- a/GuardianConnect/Classes/Credentials/GRDWireGuardConfiguration.h
+++ b/GuardianConnect/Classes/Credentials/GRDWireGuardConfiguration.h
@@ -19,6 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// @param credential the given credential out which the formatted wg-quick compatible should be generated
 + (NSString *)wireguardQuickConfigForCredential:(GRDCredential *)credential dnsServers:(NSString *_Nullable)dnsServers;
 
+/// Same as above, but allows overriding the host portion of the Peer Endpoint.
+/// Stealth Mode (GRD-1391): pass a direct IP as endpointHostOverride so the WireGuard tunnel dials
+/// the server without WireGuardKit performing a DNS lookup of the FQDN (which fails on hostile
+/// networks). Pass nil to use credential.hostname exactly as before.
++ (NSString *)wireguardQuickConfigForCredential:(GRDCredential *)credential dnsServers:(NSString *_Nullable)dnsServers endpointHostOverride:(NSString *_Nullable)endpointHostOverride;
+
 
 @end
 

--- a/GuardianConnect/Classes/Credentials/GRDWireGuardConfiguration.m
+++ b/GuardianConnect/Classes/Credentials/GRDWireGuardConfiguration.m
@@ -12,6 +12,10 @@
 
 
 + (NSString *)wireguardQuickConfigForCredential:(GRDCredential *)credential dnsServers:(NSString *_Nullable)dnsServers {
+	return [self wireguardQuickConfigForCredential:credential dnsServers:dnsServers endpointHostOverride:nil];
+}
+
++ (NSString *)wireguardQuickConfigForCredential:(GRDCredential *)credential dnsServers:(NSString *_Nullable)dnsServers endpointHostOverride:(NSString *_Nullable)endpointHostOverride {
 	if ([credential transportProtocol] != TransportWireGuard) {
 		GRDErrorLogg(@"Main credential is not a WireGuard credential.");
 		return nil;
@@ -34,7 +38,11 @@
 	config = [config stringByAppendingString:@"[Peer]\n"];
 	config = [config stringByAppendingString:[NSString stringWithFormat:@"PublicKey = %@\n", [credential serverPublicKey]]];
 	config = [config stringByAppendingString:[NSString stringWithFormat:@"AllowedIPs = 0.0.0.0/0, ::/0\n"]];
-	config = [config stringByAppendingString:[NSString stringWithFormat:@"Endpoint = %@:51821", [credential hostname]]];
+	// Stealth Mode (GRD-1391): use the caller-supplied endpoint host (a direct IP) when provided so
+	// WireGuardKit does not resolve the FQDN via DNS; otherwise fall back to the credential hostname
+	// exactly as before. The wg Endpoint accepts a literal IP or a hostname.
+	NSString *endpointHost = (endpointHostOverride != nil && endpointHostOverride.length > 0) ? endpointHostOverride : [credential hostname];
+	config = [config stringByAppendingString:[NSString stringWithFormat:@"Endpoint = %@:51821", endpointHost]];
 	config = [config stringByAppendingString:@"\n"];
 	
 	GRDDebugLog(@"Formatted WireGuard config: \n%@", config);

--- a/GuardianConnect/Classes/GRDVPNHelper.h
+++ b/GuardianConnect/Classes/GRDVPNHelper.h
@@ -176,6 +176,38 @@ NS_ASSUME_NONNULL_BEGIN
 /// payment validation mechanisms already known to the Connect API
 @property NSMutableDictionary *customSubscriberCredentialAuthKeys;
 
+
+#pragma mark - Stealth Mode (GRD-1391)
+
+/// When YES, the VPN is dialled by direct server IP (sourced from the cached sgw-ips map)
+/// instead of the SGW FQDN, so a connection can be established on hostile networks where
+/// DNS for the hostname is poisoned. OFF by default. Backed by the shared app-group
+/// defaults so the value is consistent between the app and its network extensions.
+/// Toggling this does NOT itself reconnect; callers should reconnect to apply.
+@property (nonatomic) BOOL stealthModeEnabled;
+
+/// NSUserDefaults instance scoped to `appGroupIdentifier` (falls back to standardUserDefaults
+/// if no app group identifier has been set). Used to persist the Stealth Mode toggle and the
+/// cached hostname -> IPv4 map so they are shared with the WireGuard packet tunnel extension.
+@property (nonatomic, readonly) NSUserDefaults *sharedAppGroupDefaults;
+
+/// Refreshes the locally cached secure-gateway hostname -> IPv4 map from the Connect API.
+/// This should be called on a regular cadence on clean networks REGARDLESS of whether Stealth
+/// Mode is currently enabled, so the map is already warm if the user enables Stealth Mode while
+/// already on a hostile network.
+/// MITIGATION (GRD-1391): on ANY failure (network error, non-200, empty/malformed response) the
+/// previously cached map and its timestamp are left untouched — a failed refresh never destroys
+/// last-known-good IPs. Only a confirmed non-empty success overwrites the cache.
+- (void)refreshStealthIPCacheWithCompletion:(void (^_Nullable)(NSError * _Nullable error))completion;
+
+/// Returns the address that should be used as the VPN dial target (IKEv2 serverAddress /
+/// WireGuard Endpoint host) for the given credential.
+/// Returns the cached direct IP only when Stealth Mode is enabled AND a cached IP exists for the
+/// credential's hostname; otherwise returns credential.hostname unchanged.
+/// MITIGATION (GRD-1391): the FQDN fallback guarantees that with Stealth Mode off, or on a cache
+/// miss, the dial target is byte-for-byte what it was before this feature existed.
+- (NSString *)dialableServerAddressForCredential:(GRDCredential *)credential;
+
 #if !TARGET_OS_OSX
 @property UIBackgroundTaskIdentifier bgTask;
 #endif

--- a/GuardianConnect/Classes/GRDVPNHelper.m
+++ b/GuardianConnect/Classes/GRDVPNHelper.m
@@ -304,32 +304,125 @@
 		return;
 	}
 	
+	// MITIGATION (GRD-1391): the pre-flight server-status probe below hits
+	// https://<hostname>/vpnsrv/api/server-status, which requires a DNS lookup of the SGW hostname
+	// and, on failure, kicks off a full credential migration (which itself needs API/DNS access).
+	// On a hostile network that strands the user before the tunnel is ever attempted. In Stealth
+	// Mode we skip the probe and proceed straight to building the direct-IP connection; the
+	// on-demand connect rule plus the IKE/WireGuard handshake themselves validate reachability.
+	if ([self stealthModeEnabled] == YES) {
+		GRDWarningLogg(@"[Stealth] Skipping pre-flight server-status probe; proceeding with direct-IP connection");
+		[self _proceedWithConfiguredConnection:completion];
+		return;
+	}
+
 	[[GRDGatewayAPI new] getServerStatusWithCompletion:^(NSString * _Nullable errorMessage) {
 		if (errorMessage != nil) {
 			GRDErrorLogg(@"VPN server status check failed with error: %@", errorMessage);
 			[self migrateUserForTransportProtocol:[self.mainCredential transportProtocol] withCompletion:completion];
 			return;
 		}
-		
-		if ([self.mainCredential transportProtocol] == TransportIKEv2) {
-			if ([self.mainCredential username] == nil || [self.mainCredential passwordRef] == nil || [self.mainCredential apiAuthToken] == nil) {
-				GRDErrorLogg(@"[IKEv2] Missing one or more required credentials, migrating!");
-				[self migrateUserForTransportProtocol:[self.mainCredential transportProtocol] withCompletion:completion];
-				return;
-			}
-			
-			[self _startIKEv2ConnectionWithCompletion:completion];
-			
-		} else {
-			if ([self.mainCredential serverPublicKey] == nil || [self.mainCredential IPv4Address] == nil || [self.mainCredential clientId] == nil || [self.mainCredential apiAuthToken] == nil) {
-				GRDErrorLogg(@"[WireGuard] Missing required credentials or server connection details. Migrating!");
-				[self migrateUserForTransportProtocol:[self.mainCredential transportProtocol] withCompletion:completion];
-				return;
-			}
-			
-			[self _startWireGuardConnectionWithCompletion:completion];
-		}
+
+		[self _proceedWithConfiguredConnection:completion];
 	}];
+}
+
+/// Validates the protocol-specific credential fields and starts the appropriate transport.
+/// Extracted from configureAndConnectVPNTunnelWithCompletion: (GRD-1391) so the exact same logic
+/// can run either after the pre-flight server-status probe (normal mode) or directly (Stealth Mode).
+- (void)_proceedWithConfiguredConnection:(void (^_Nullable)(GRDVPNHelperStatusCode, NSError * _Nullable))completion {
+	if ([self.mainCredential transportProtocol] == TransportIKEv2) {
+		if ([self.mainCredential username] == nil || [self.mainCredential passwordRef] == nil || [self.mainCredential apiAuthToken] == nil) {
+			GRDErrorLogg(@"[IKEv2] Missing one or more required credentials, migrating!");
+			[self migrateUserForTransportProtocol:[self.mainCredential transportProtocol] withCompletion:completion];
+			return;
+		}
+
+		[self _startIKEv2ConnectionWithCompletion:completion];
+
+	} else {
+		if ([self.mainCredential serverPublicKey] == nil || [self.mainCredential IPv4Address] == nil || [self.mainCredential clientId] == nil || [self.mainCredential apiAuthToken] == nil) {
+			GRDErrorLogg(@"[WireGuard] Missing required credentials or server connection details. Migrating!");
+			[self migrateUserForTransportProtocol:[self.mainCredential transportProtocol] withCompletion:completion];
+			return;
+		}
+
+		[self _startWireGuardConnectionWithCompletion:completion];
+	}
+}
+
+
+# pragma mark - Stealth Mode (GRD-1391)
+
+- (NSUserDefaults *)sharedAppGroupDefaults {
+	if (self.appGroupIdentifier != nil && [self.appGroupIdentifier isEqualToString:@""] == NO) {
+		NSUserDefaults *groupDefaults = [[NSUserDefaults alloc] initWithSuiteName:self.appGroupIdentifier];
+		if (groupDefaults != nil) {
+			return groupDefaults;
+		}
+	}
+
+	// Fallback so Stealth Mode still functions in contexts without an app group configured
+	// (unit tests / sample app). The IKEv2 path runs entirely in the main app process and so
+	// never depends on the shared suite; WireGuard relies on the app group being set, which is
+	// already enforced in _startWireGuardConnectionWithCompletion:.
+	return [NSUserDefaults standardUserDefaults];
+}
+
+- (BOOL)stealthModeEnabled {
+	return [[self sharedAppGroupDefaults] boolForKey:kGRDStealthModeEnabled];
+}
+
+- (void)setStealthModeEnabled:(BOOL)stealthModeEnabled {
+	[[self sharedAppGroupDefaults] setBool:stealthModeEnabled forKey:kGRDStealthModeEnabled];
+}
+
+- (void)refreshStealthIPCacheWithCompletion:(void (^_Nullable)(NSError * _Nullable))completion {
+	[[GRDHousekeepingAPI new] requestAllServerIPsWithCompletion:^(NSDictionary<NSString *, NSString *> * _Nullable ipMap, NSError * _Nullable error) {
+		// MITIGATION (GRD-1391): never clobber a good cache on a failed/empty refresh. A user who
+		// flips Stealth Mode on to rescue a stuck connection is, by definition, likely already on a
+		// hostile network where this request fails. Retaining the last-known-good map is what makes
+		// "enable Stealth Mode while already on a bad network" work. Only a confirmed non-empty
+		// success overwrites the cache + timestamp below.
+		if (error != nil || ipMap.count == 0) {
+			GRDWarningLogg(@"[Stealth] IP cache refresh failed or returned empty; retaining existing cache. Error: %@", error);
+			if (completion) completion(error);
+			return;
+		}
+
+		NSUserDefaults *defaults = [self sharedAppGroupDefaults];
+		[defaults setObject:ipMap forKey:kGRDStealthSGWIPCache];
+		[defaults setObject:[NSDate date] forKey:kGRDStealthSGWIPCacheDate];
+		GRDDebugLog(@"[Stealth] Refreshed SGW IP cache with %lu entries", (unsigned long)ipMap.count);
+		if (completion) completion(nil);
+	}];
+}
+
+- (NSString *)dialableServerAddressForCredential:(GRDCredential *)credential {
+	NSString *hostname = credential.hostname;
+
+	// MITIGATION (GRD-1391): with Stealth Mode OFF we MUST return the FQDN unchanged so behaviour is
+	// byte-for-byte identical to before this feature existed. Only override the dial target when the
+	// user has explicitly opted in.
+	if ([self stealthModeEnabled] == NO) {
+		return hostname;
+	}
+	if (hostname == nil || hostname.length == 0) {
+		return hostname;
+	}
+
+	NSDictionary<NSString *, NSString *> *ipMap = [[self sharedAppGroupDefaults] dictionaryForKey:kGRDStealthSGWIPCache];
+	NSString *cachedIP = ipMap[hostname];
+
+	// MITIGATION (GRD-1391): on a cache miss fall back to the FQDN rather than failing the connection.
+	// Worst case the user is no worse off than with Stealth Mode disabled.
+	if ([cachedIP isKindOfClass:[NSString class]] == NO || cachedIP.length == 0) {
+		GRDWarningLogg(@"[Stealth] No cached IP for hostname '%@'; falling back to FQDN dial target", hostname);
+		return hostname;
+	}
+
+	GRDDebugLog(@"[Stealth] Dialling '%@' by direct IP '%@'", hostname, cachedIP);
+	return cachedIP;
 }
 
 
@@ -400,7 +493,12 @@
 			
 			if ([self onDemand]) {
 				vpnManager.onDemandEnabled = YES;
-				vpnManager.onDemandRules = [GRDVPNHelper _vpnOnDemandRulesForHostname:self.mainCredential.hostname withProbeURL:!self.vpnKillSwitchEnabled disconnectOnEthernet:self.disconnectOnEthernet disconnectTrustedNetworks:self.disconnectOnTrustedNetworks trustedNetworks:self.trustedNetworks];
+				// MITIGATION (GRD-1391): the on-demand probe URL is https://<hostname>/vpnsrv/api/server-status,
+				// which requires a DNS lookup of the hostname; on a hostile network it never returns 200 so the
+				// VPN would never auto-connect. In Stealth Mode we drop the probe URL (the always-connect rule
+				// remains), so on-demand connects without any DNS dependency. Probe behaviour is unchanged when
+				// Stealth Mode is off.
+				vpnManager.onDemandRules = [GRDVPNHelper _vpnOnDemandRulesForHostname:self.mainCredential.hostname withProbeURL:(!self.vpnKillSwitchEnabled && [self stealthModeEnabled] == NO) disconnectOnEthernet:self.disconnectOnEthernet disconnectTrustedNetworks:self.disconnectOnTrustedNetworks trustedNetworks:self.trustedNetworks];
 				
 			} else {
 				vpnManager.onDemandEnabled = NO;
@@ -438,7 +536,12 @@
 
 - (NEVPNProtocolIKEv2 *)_prepareIKEv2ParametersForServer:(GRDSGWServer * _Nonnull)server eapUsername:(NSString * _Nonnull)user eapPasswordRef:(NSData * _Nonnull)passRef withCertificateType:(NEVPNIKEv2CertificateType)certType {
 	NEVPNProtocolIKEv2 *protocolConfig = [[NEVPNProtocolIKEv2 alloc] init];
-	protocolConfig.serverAddress = server.hostname;
+	// Feature/MITIGATION (GRD-1391): in Stealth Mode dial the server by direct IP to avoid a DNS
+	// lookup of the hostname on hostile networks. serverCertificateCommonName and remoteIdentifier
+	// MUST remain the FQDN — the gateway presents a certificate for the FQDN and asserts the FQDN as
+	// its IKE identity, so only the transport dial target moves; identity validation is unchanged.
+	// With Stealth Mode off, dialableServerAddressForCredential: returns server.hostname unchanged.
+	protocolConfig.serverAddress = [self dialableServerAddressForCredential:self.mainCredential];
 	protocolConfig.serverCertificateCommonName = server.hostname;
 	protocolConfig.remoteIdentifier = server.hostname;
 	protocolConfig.enablePFS = YES;
@@ -499,7 +602,11 @@
 	}
 	
 	[[GRDTunnelManager sharedManager] ensureTunnelManagerWithCompletion:^(NETunnelProviderManager * _Nullable tunnelManager, NSString * _Nullable errorMessage) {
-		NSString *wireGuardConfig = [GRDWireGuardConfiguration wireguardQuickConfigForCredential:self.mainCredential dnsServers:self.preferredDNSServers];
+		// Stealth Mode (GRD-1391): resolve the dial target once (direct IP when Stealth Mode is on and
+		// a cached IP exists, otherwise the FQDN) and reuse it for both the wg Endpoint and the
+		// protocol's serverAddress so they stay consistent and no DNS lookup of the hostname is needed.
+		NSString *wgDialAddress = [self dialableServerAddressForCredential:self.mainCredential];
+		NSString *wireGuardConfig = [GRDWireGuardConfiguration wireguardQuickConfigForCredential:self.mainCredential dnsServers:self.preferredDNSServers endpointHostOverride:wgDialAddress];
 		OSStatus saveStatus = [GRDKeychain storePassword:wireGuardConfig forAccount:kKeychainStr_WireGuardConfig];
 		if (saveStatus != errSecSuccess) {
 			if (completion) completion(GRDVPNHelperFail, [GRDErrorHelper errorWithErrorCode:kGRDGenericErrorCode andErrorMessage:@"[GRDTunnel] Failed to store WireGuard credentials in system keychain"]);
@@ -507,7 +614,7 @@
 		}
 		
 		NETunnelProviderProtocol *protocol = [NETunnelProviderProtocol new];
-		protocol.serverAddress 				= self.mainCredential.hostname;
+		protocol.serverAddress 				= wgDialAddress; // GRD-1391: matches the wg Endpoint dial target (direct IP in Stealth Mode, else FQDN)
 		protocol.providerBundleIdentifier 	= self.tunnelProviderBundleIdentifier;
 		protocol.passwordReference 			= [GRDKeychain getPasswordRefForAccount:kKeychainStr_WireGuardConfig];
 		protocol.username 					= [self.mainCredential clientId];
@@ -521,7 +628,9 @@
 		tunnelManager.protocolConfiguration = protocol;
 		tunnelManager.enabled = YES;
 		tunnelManager.onDemandEnabled = YES;
-		tunnelManager.onDemandRules = [GRDVPNHelper _vpnOnDemandRulesForHostname:self.mainCredential.hostname withProbeURL:!self.vpnKillSwitchEnabled disconnectOnEthernet:self.disconnectOnEthernet disconnectTrustedNetworks:self.disconnectOnTrustedNetworks trustedNetworks:self.trustedNetworks];
+		// MITIGATION (GRD-1391): same as the IKEv2 path — drop the DNS-dependent probe URL in Stealth
+		// Mode so on-demand can auto-connect on hostile networks. The always-connect rule remains.
+		tunnelManager.onDemandRules = [GRDVPNHelper _vpnOnDemandRulesForHostname:self.mainCredential.hostname withProbeURL:(!self.vpnKillSwitchEnabled && [self stealthModeEnabled] == NO) disconnectOnEthernet:self.disconnectOnEthernet disconnectTrustedNetworks:self.disconnectOnTrustedNetworks trustedNetworks:self.trustedNetworks];
 		
 		NSString *finalDescription = self.grdTunnelProviderManagerLocalizedDescription;
 		if (self.appendServerRegionToGRDTunnelProviderManagerLocalizedDescription == YES) {

--- a/GuardianConnect/Shared.h
+++ b/GuardianConnect/Shared.h
@@ -119,5 +119,18 @@ static NSString * const kGRDKillSwitchEnabled       	= @"kGRDKillSwitchEnabled";
 
 static NSString * const kGRDDeviceFilterConfigBlocklist = @"kGRDDeviceFilterConfigBlocklist";
 
+
+#pragma mark - Stealth Mode (GRD-1391)
+// Stealth Mode connects the VPN by direct IP instead of FQDN so the connection can
+// be established on hostile networks where DNS for the SGW hostname is poisoned
+// (e.g. resolves to 0.0.0.0). It is OFF by default; when off, all connect-path logic
+// behaves exactly as before. The FQDN (credential.hostname) is never overwritten;
+// only the dial target is substituted, and only when a cached IP is available.
+// NOTE (GRD-1391 future work): the IP cache is IPv4-only. IPv6 / dual-stack is not
+// yet supported; v6-only or v4-less nodes fall back to connecting by FQDN.
+static NSString * const kGRDStealthModeEnabled			= @"kGRDStealthModeEnabled";
+static NSString * const kGRDStealthSGWIPCache			= @"kGRDStealthSGWIPCache";		// NSDictionary<hostname (NSString), ipv4 (NSString)>
+static NSString * const kGRDStealthSGWIPCacheDate		= @"kGRDStealthSGWIPCacheDate";	// NSDate of last successful refresh
+
 NS_ASSUME_NONNULL_END
 #endif /* Shared_h */


### PR DESCRIPTION
Stealth Mode dials the VPN by direct server IP instead of FQDN. Connections succeed on hostile networks that poison DNS for the SGW hostname. OFF by default; behavior is identical when disabled. IKEv2 serverCertificateCommonName/remoteIdentifier stay the FQDN (only the dial target moves); WireGuard `Endpoint`/`serverAddress` dial the IP. On-demand probe URL is dropped and the pre-flight `server-status` check is skipped in Stealth Mode. IPs come from the cached Guardian Connect API response map with a non-destructive refresh. IPv4-only; IPv6 is future work.

Related-To: https://dnsfilter.atlassian.net/browse/GRD-1391